### PR TITLE
hosts.bat should look in the current directory.

### DIFF
--- a/hosts.bat
+++ b/hosts.bat
@@ -1,6 +1,6 @@
 REM This blocks MS telemetry IP's from hosts file. Appends to current hosts file, only run once
 REM Windows 10 bypasses this, if running WIN10 add the entries in the file 'hostslist' to your router or firewall blocklist
 REM Put all files in your Downloads directory. Right click and run this file as administrator
-type %homepath%\Downloads\hosts >> %windir%\system32\Drivers\etc\hosts
+type %~dp0hosts >> %windir%\system32\Drivers\etc\hosts
 echo Completed
 pause

--- a/hosts.bat
+++ b/hosts.bat
@@ -1,6 +1,6 @@
 REM This blocks MS telemetry IP's from hosts file. Appends to current hosts file, only run once
 REM Windows 10 bypasses this, if running WIN10 add the entries in the file 'hostslist' to your router or firewall blocklist
 REM Put all files in your Downloads directory. Right click and run this file as administrator
-type %~dp0hosts.txt >> %windir%\system32\Drivers\etc\hosts
+type %~dp0hosts >> %windir%\system32\Drivers\etc\hosts
 echo Completed
 pause

--- a/hosts.bat
+++ b/hosts.bat
@@ -1,6 +1,6 @@
 REM This blocks MS telemetry IP's from hosts file. Appends to current hosts file, only run once
 REM Windows 10 bypasses this, if running WIN10 add the entries in the file 'hostslist' to your router or firewall blocklist
 REM Put all files in your Downloads directory. Right click and run this file as administrator
-type %~dp0hosts >> %windir%\system32\Drivers\etc\hosts
+type %~dp0hosts.txt >> %windir%\system32\Drivers\etc\hosts
 echo Completed
 pause


### PR DESCRIPTION
hosts.bat only functions correctly when the list of new hosts [hosts.txt] is in %homepath%\Downloads\.  This change makes hosts.bat look in the current directory.

~~Also, I fixed a typo where the script was missing the .txt extension, preventing it from functioning correctly in the first place.~~ Nevermind I'm an idiot.